### PR TITLE
support aggregates on uninitialized data structure

### DIFF
--- a/src/component/btree.ts
+++ b/src/component/btree.ts
@@ -226,7 +226,10 @@ export async function aggregateBetweenHandler(
   ctx: { db: DatabaseReader },
   args: { k1?: Key; k2?: Key }
 ) {
-  const tree = (await getTree(ctx.db))!;
+  const tree = await getTree(ctx.db);
+  if (tree === null) {
+    return { count: 0, sum: 0 };
+  }
   return await aggregateBetweenInNode(ctx.db, tree.root, args.k1, args.k2);
 }
 
@@ -355,7 +358,10 @@ export async function atOffsetHandler(
   ctx: { db: DatabaseReader },
   args: { offset: number, k1?: Key, k2?: Key }
 ) {
-  const tree = (await getTree(ctx.db))!;
+  const tree = await getTree(ctx.db);
+  if (tree === null) {
+    throw new ConvexError("tree is empty");
+  }
   return await atOffsetInNode(ctx.db, tree.root, args.offset, args.k1, args.k2);
 }
 
@@ -369,7 +375,10 @@ export async function atNegativeOffsetHandler(
   ctx: { db: DatabaseReader },
   args: { offset: number, k1?: Key, k2?: Key }
 ) {
-  const tree = (await getTree(ctx.db))!;
+  const tree = await getTree(ctx.db);
+  if (tree === null) {
+    throw new ConvexError("tree is empty");
+  }
   return await negativeOffsetInNode(ctx.db, tree.root, args.offset, args.k1, args.k2);
 }
 
@@ -868,7 +877,10 @@ export async function paginateHandler(
     k2?: Key,
   },
 ) {
-  const tree = await mustGetTree(ctx.db);
+  const tree = await getTree(ctx.db);
+  if (tree === null) {
+    return { page: [], cursor: "", isDone: true };
+  }
   return await paginateInNode(
     ctx.db,
     tree.root,


### PR DESCRIPTION
<!-- Describe your PR here. -->

currently we throw an error if the tree is uninitialized. but instead we could consider the tree to be empty.

allow aggregate on empty tree which has count 0 and sum 0. and `paginate` returns an empty page. and `offset` returns zero, and `atOffset` throws a more clear error.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
