### PR TITLE
example use migrations component for backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,9 @@ ways to perform migrations, but here's an overview of one way:
    aggregate component.
 3. Use a paginated background
    [migration](https://www.npmjs.com/package/@convex-dev/migrations)
-   to walk all existing data and call `insertIfDoesNotExist`.
+   to walk all existing data and call `insertIfDoesNotExist`. In the example,
+   you would run `runAggregateBackfill` in
+   [leaderboard.ts](example/convex/leaderboard.ts).
 4. Now all of the data is represented in the `Aggregate`, you can start calling
    read methods like `aggregate.count(ctx)` and you can change the write methods
    back (`insertIfDoesNotExist` -> `insert` etc.).

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -589,4 +589,89 @@ export declare const components: {
       >;
     };
   };
+  migrations: {
+    lib: {
+      cancel: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+      cancelAll: FunctionReference<
+        "mutation",
+        "internal",
+        { sinceTs?: number },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        any
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; names?: Array<string> },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      migrate: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          dryRun: boolean;
+          fnHandle: string;
+          name: string;
+          next?: Array<{ fnHandle: string; name: string }>;
+        },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+    };
+  };
 };

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -1,5 +1,6 @@
 import { defineApp } from "convex/server";
 import aggregate from "@convex-dev/aggregate/convex.config";
+import migrations from "@convex-dev/migrations/convex.config";
 
 const app = defineApp();
 app.use(aggregate, { name: "aggregateByScore" });
@@ -7,5 +8,7 @@ app.use(aggregate, { name: "aggregateScoreByUser" });
 app.use(aggregate, { name: "music" });
 app.use(aggregate, { name: "photos" });
 app.use(aggregate, { name: "stats" });
+
+app.use(migrations);
 
 export default app;

--- a/example/convex/leaderboard.ts
+++ b/example/convex/leaderboard.ts
@@ -41,7 +41,13 @@ export const clearAggregates = internalMutation({
     await aggregateScoreByUser.clear(ctx);
   },
 });
-export const runAggregateBackfill = migrations.runner(internal.leaderboard.backfillAggregatesMigration);
+
+// This is what you can run, from the Convex dashboard or with `npx convex run`,
+// to backfill aggregates for existing leaderboard entries, if you created the
+// leaderboard before adding the aggregate components.
+export const runAggregateBackfill = migrations.runner(
+  internal.leaderboard.backfillAggregatesMigration
+);
 
 export const addScore = mutation({
   args: {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@convex-dev/aggregate": "file:..",
+        "@convex-dev/migrations": "^0.2.1",
         "convex": "^1.17.0",
         "convex-helpers": "^0.1.61",
-        "isaac": "^0.0.5",
         "rand-seed": "^2.1.7"
       },
       "devDependencies": {
@@ -26,6 +26,7 @@
       }
     },
     "..": {
+      "name": "@convex-dev/aggregate",
       "version": "0.1.15",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -48,6 +49,14 @@
     "node_modules/@convex-dev/aggregate": {
       "resolved": "..",
       "link": true
+    },
+    "node_modules/@convex-dev/migrations": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@convex-dev/migrations/-/migrations-0.2.1.tgz",
+      "integrity": "sha512-n4vBPk3IURqvnpFR5wLs9cPeTlBmTTyvtbdE3Mda6CrbpBrEm9t6B9jmPkioqsi1PSS4ezg4yYd8qDj7n0Bo5A==",
+      "peerDependencies": {
+        "convex": "~1.16.5 || ~1.17.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.0",
@@ -1506,11 +1515,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/isaac": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/isaac/-/isaac-0.0.5.tgz",
-      "integrity": "sha512-KVtdbh4E0xebBIyGjVdEUyBAJ6QmfD5Q2jZXalthodNc5DeHg6ByvoymLSAAWPpZ6MjrcyZLuw8+u5dj1LbBLg=="
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2003,6 +2007,12 @@
         "typescript-eslint": "^8.4.0",
         "vitest": "^2.1.1"
       }
+    },
+    "@convex-dev/migrations": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@convex-dev/migrations/-/migrations-0.2.1.tgz",
+      "integrity": "sha512-n4vBPk3IURqvnpFR5wLs9cPeTlBmTTyvtbdE3Mda6CrbpBrEm9t6B9jmPkioqsi1PSS4ezg4yYd8qDj7n0Bo5A==",
+      "requires": {}
     },
     "@esbuild/aix-ppc64": {
       "version": "0.23.0",
@@ -2876,11 +2886,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "isaac": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/isaac/-/isaac-0.0.5.tgz",
-      "integrity": "sha512-KVtdbh4E0xebBIyGjVdEUyBAJ6QmfD5Q2jZXalthodNc5DeHg6ByvoymLSAAWPpZ6MjrcyZLuw8+u5dj1LbBLg=="
     },
     "isexe": {
       "version": "2.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@convex-dev/aggregate": "file:..",
+    "@convex-dev/migrations": "^0.2.1",
     "convex": "^1.17.0",
     "convex-helpers": "^0.1.61",
     "rand-seed": "^2.1.7"


### PR DESCRIPTION
<!-- Describe your PR here. -->

a couple users have had difficulty figuring out how to backfill aggregates. add an example using the migrations component.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
