### PR TITLE
optional namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,10 @@ import { mutation as rawMutation } from "./_generated/server";
 import { TableAggregate } from "@convex-dev/aggregate";
 
 const aggregate = new TableAggregate<{
-  Namespace: undefined;
   Key: number;
   DataModel: DataModel;
   TableName: "mytable";
 }>(components.aggregate, {
-  namespace: (doc) => undefined, // disable namespacing.
   sortKey: (doc) => doc._creationTime, // Allows querying across time ranges.
   sumValue: (doc) => doc.value, // The value to be used in `.sum` calculations.
 });
@@ -308,12 +306,10 @@ If you don't need the ordering, partitioning, or summing behavior of
 
 ```ts
 const randomize = new TableAggregate<{
-  Namespace: undefined;
   Key: null;
   DataModel: DataModel;
   TableName: "mytable";
 }>(components.aggregate, {
-  namespace: (doc) => undefined,
   sortKey: (doc) => null,
 });
 ```
@@ -397,7 +393,6 @@ import { DirectAggregate } from "@convex-dev/aggregate";
 // Note the `id` should be unique to be a tie-breaker in case two data points
 // have the same key.
 const aggregate = new DirectAggregate<{
-  Namespace: undefined;
   Key: number;
   Id: string;
 }>(components.aggregate);

--- a/example/convex/leaderboard.ts
+++ b/example/convex/leaderboard.ts
@@ -13,21 +13,17 @@ export const migrations = new Migrations<DataModel>(components.migrations);
 export const run = migrations.runner();
 
 const aggregateByScore = new TableAggregate<{
-  Namespace: undefined;
   Key: number;
   DataModel: DataModel;
   TableName: "leaderboard";
 }>(components.aggregateByScore, {
-  namespace: (_doc) => undefined,
   sortKey: (doc) => doc.score,
 });
 const aggregateScoreByUser = new TableAggregate<{
   Key: [string, number];
   DataModel: DataModel;
   TableName: "leaderboard";
-  Namespace: undefined;
 }>(components.aggregateScoreByUser, {
-  namespace: (_doc) => undefined,
   sortKey: (doc) => [doc.name, doc.score],
   sumValue: (doc) => doc.score,
 });

--- a/example/convex/shuffle.ts
+++ b/example/convex/shuffle.ts
@@ -13,10 +13,8 @@ import Rand from "rand-seed";
 const randomize = new TableAggregate<{
   DataModel: DataModel;
   TableName: "music";
-  Namespace: undefined;
   Key: null;
 }>(components.music, {
-  namespace: () => undefined,
   sortKey: () => null,
 });
 

--- a/example/convex/stats.ts
+++ b/example/convex/stats.ts
@@ -8,7 +8,6 @@ import { DirectAggregate } from "@convex-dev/aggregate";
 import { components } from "./_generated/api";
 
 const stats = new DirectAggregate<{
-  Namespace: undefined;
   Key: number;
   Id: string;
 }>(components.stats);

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "dependencies": {
         "levn": "^0.4.1"
@@ -1041,9 +1041,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2228,9 +2228,9 @@
       "dev": true
     },
     "@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "requires": {
         "levn": "^0.4.1"
@@ -2544,9 +2544,9 @@
       "requires": {}
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -491,17 +491,19 @@ export class Aggregate<
 export type DirectAggregateType<
   K extends Key,
   ID extends string,
-  Namespace extends ConvexValue | undefined,
+  Namespace extends ConvexValue | undefined = undefined,
 > = {
   Key: K;
   Id: ID;
-  Namespace: Namespace;
+  Namespace?: Namespace;
 };
 type AnyDirectAggregateType = DirectAggregateType<
   Key,
   string,
   ConvexValue | undefined
 >;
+type DirectAggregateNamespace<T extends AnyDirectAggregateType> =
+  "Namespace" extends keyof T ? T["Namespace"] : undefined;
 
 /**
  * A DirectAggregate is an Aggregate where you can insert, delete, and replace
@@ -512,7 +514,7 @@ type AnyDirectAggregateType = DirectAggregateType<
  */
 export class DirectAggregate<
   T extends AnyDirectAggregateType,
-> extends Aggregate<T["Key"], T["Id"], T["Namespace"]> {
+> extends Aggregate<T["Key"], T["Id"], DirectAggregateNamespace<T>> {
   /**
    * Insert a new key into the data structure.
    * The id should be unique.
@@ -525,7 +527,7 @@ export class DirectAggregate<
     ctx: RunMutationCtx,
     args: NamespacedArgs<
       { key: T["Key"]; id: T["Id"]; sumValue?: number },
-      T["Namespace"]
+      DirectAggregateNamespace<T>
     >
   ): Promise<void> {
     await this._insert(
@@ -542,7 +544,10 @@ export class DirectAggregate<
    */
   async delete(
     ctx: RunMutationCtx,
-    args: NamespacedArgs<{ key: T["Key"]; id: T["Id"] }, T["Namespace"]>
+    args: NamespacedArgs<
+      { key: T["Key"]; id: T["Id"] },
+      DirectAggregateNamespace<T>
+    >
   ): Promise<void> {
     await this._delete(ctx, namespaceFromArg(args), args.key, args.id);
   }
@@ -553,10 +558,13 @@ export class DirectAggregate<
    */
   async replace(
     ctx: RunMutationCtx,
-    currentItem: NamespacedArgs<{ key: T["Key"]; id: T["Id"] }, T["Namespace"]>,
+    currentItem: NamespacedArgs<
+      { key: T["Key"]; id: T["Id"] },
+      DirectAggregateNamespace<T>
+    >,
     newItem: NamespacedArgs<
       { key: T["Key"]; sumValue?: number },
-      T["Namespace"]
+      DirectAggregateNamespace<T>
     >
   ): Promise<void> {
     await this._replace(
@@ -581,7 +589,7 @@ export class DirectAggregate<
     ctx: RunMutationCtx,
     args: NamespacedArgs<
       { key: T["Key"]; id: T["Id"]; sumValue?: number },
-      T["Namespace"]
+      DirectAggregateNamespace<T>
     >
   ): Promise<void> {
     await this._insertIfDoesNotExist(
@@ -594,16 +602,22 @@ export class DirectAggregate<
   }
   async deleteIfExists(
     ctx: RunMutationCtx,
-    args: NamespacedArgs<{ key: T["Key"]; id: T["Id"] }, T["Namespace"]>
+    args: NamespacedArgs<
+      { key: T["Key"]; id: T["Id"] },
+      DirectAggregateNamespace<T>
+    >
   ): Promise<void> {
     await this._deleteIfExists(ctx, namespaceFromArg(args), args.key, args.id);
   }
   async replaceOrInsert(
     ctx: RunMutationCtx,
-    currentItem: NamespacedArgs<{ key: T["Key"]; id: T["Id"] }, T["Namespace"]>,
+    currentItem: NamespacedArgs<
+      { key: T["Key"]; id: T["Id"] },
+      DirectAggregateNamespace<T>
+    >,
     newItem: NamespacedArgs<
       { key: T["Key"]; sumValue?: number },
-      T["Namespace"]
+      DirectAggregateNamespace<T>
     >
   ): Promise<void> {
     await this._replaceOrInsert(


### PR DESCRIPTION
<!-- Describe your PR here. -->

Make the Namespace type parameter optional, and when it isn't specified,
the namespace function is also optional (or has to return undefined).

One pro user already wrote in about `this.options.namespace is not a function` so I figure let's make it more forgiving when namespaces aren't being used

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
