### PR TITLE
assert that offset is an integer

### DIFF
--- a/src/component/btree.ts
+++ b/src/component/btree.ts
@@ -372,6 +372,12 @@ export async function atOffsetHandler(
   ctx: { db: DatabaseReader },
   args: { offset: number; k1?: Key; k2?: Key; namespace?: Namespace }
 ) {
+  if (args.offset < 0) {
+    throw new Error("offset must be non-negative");
+  }
+  if (args.offset !== Math.floor(args.offset)) {
+    throw new Error("offset must be an integer");
+  }
   const tree = await getTree(ctx.db, args.namespace);
   if (tree === null) {
     throw new ConvexError("tree is empty");
@@ -394,6 +400,12 @@ export async function atNegativeOffsetHandler(
   ctx: { db: DatabaseReader },
   args: { offset: number; k1?: Key; k2?: Key; namespace?: Namespace }
 ) {
+  if (args.offset < 0) {
+    throw new Error("offset must be non-negative");
+  }
+  if (args.offset !== Math.floor(args.offset)) {
+    throw new Error("offset must be an integer");
+  }
   const tree = await getTree(ctx.db, args.namespace);
   if (tree === null) {
     throw new ConvexError("tree is empty");


### PR DESCRIPTION
<!-- Describe your PR here. -->

users in discord are reporting errors that look like

```
offset exceeded count by -3.9999999999990905
```

https://discord.com/channels/1019350475847499849/1347058269528526878/1347058269528526878

which could be from two root causes:

1. btree nodes are somehow getting counts that are not integers. i checked the float64 spec (and asked chatgpt deep research) and I don't see how this could happen, since all we do is start with 0 or 1 and do addition or subtraction.
2. the input offset is not a precise integer

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
