### PR TITLE
Mikec/optional bounds for count

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -19,6 +19,7 @@ const schema = defineSchema({
   photos: defineTable({
     album: v.string(),
     url: v.string(),
+    score: v.number(),
   }),
 });
 
@@ -31,23 +32,38 @@ function setupTest() {
 type ConvexTest = ReturnType<typeof setupTest>;
 type DataModel = DataModelFromSchemaDefinition<typeof schema>;
 
+// Helper function to create aggregates with fresh instances
+function createAggregates() {
+  const aggregate = new TableAggregate(components.aggregate, {
+    sortKey: (doc) => doc.value,
+  });
+
+  const aggregateWithNamespace = new TableAggregate<{
+    Namespace: string;
+    Key: number;
+    DataModel: DataModel;
+    TableName: "photos";
+  }>(components.aggregate, {
+    namespace: (doc) => doc.album,
+    sortKey: (doc) => doc.score, // Use score instead of _creationTime for predictable tests
+  });
+
+  return { aggregate, aggregateWithNamespace };
+}
+
 describe("TableAggregate", () => {
   describe("count", () => {
     let t: ConvexTest;
-    let aggregate = new TableAggregate(components.aggregate, {
-      sortKey: (doc) => doc.value,
-    });
+    let aggregate: ReturnType<typeof createAggregates>["aggregate"];
 
     beforeEach(() => {
       t = setupTest();
-      aggregate = new TableAggregate(components.aggregate, {
-        sortKey: (doc) => doc.value,
-      });
+      ({ aggregate } = createAggregates());
     });
 
-    const exec = async (_aggregate = aggregate) => {
+    const exec = async () => {
       return await t.run(async (ctx) => {
-        return await _aggregate.count(ctx);
+        return await aggregate.count(ctx);
       });
     };
 
@@ -82,16 +98,12 @@ describe("TableAggregate", () => {
 
   describe("clearAll", () => {
     let t: ConvexTest;
-    let aggregate = new TableAggregate(components.aggregate, {
-      sortKey: (doc) => doc.value,
-    });
+    let aggregate: ReturnType<typeof createAggregates>["aggregate"];
 
     beforeEach(() => {
       vi.useFakeTimers();
       t = setupTest();
-      aggregate = new TableAggregate(components.aggregate, {
-        sortKey: (doc) => doc.value,
-      });
+      ({ aggregate } = createAggregates());
     });
 
     afterEach(() => {
@@ -183,18 +195,13 @@ describe("TableAggregate", () => {
 
 describe("TableAggregate with namespace", () => {
   let t: ConvexTest;
-  const aggregateWithNamespace = new TableAggregate<{
-    Namespace: string;
-    Key: number;
-    DataModel: DataModel;
-    TableName: "photos";
-  }>(components.aggregate, {
-    namespace: (doc) => doc.album,
-    sortKey: (doc) => doc._creationTime,
-  });
+  let aggregateWithNamespace: ReturnType<
+    typeof createAggregates
+  >["aggregateWithNamespace"];
 
   beforeEach(() => {
     t = setupTest();
+    ({ aggregateWithNamespace } = createAggregates());
   });
 
   describe("count", () => {
@@ -243,6 +250,7 @@ describe("TableAggregate with namespace", () => {
         const id1 = await ctx.db.insert("photos", {
           album: "vacation",
           url: "photo1.jpg",
+          score: 10,
         });
         const doc1 = await ctx.db.get(id1);
         await photosAggregate.insert(ctx, doc1!);
@@ -250,6 +258,7 @@ describe("TableAggregate with namespace", () => {
         const id2 = await ctx.db.insert("photos", {
           album: "vacation",
           url: "photo2.jpg",
+          score: 20,
         });
         const doc2 = await ctx.db.get(id2);
         await photosAggregate.insert(ctx, doc2!);
@@ -257,6 +266,7 @@ describe("TableAggregate with namespace", () => {
         const id3 = await ctx.db.insert("photos", {
           album: "family",
           url: "photo3.jpg",
+          score: 30,
         });
         const doc3 = await ctx.db.get(id3);
         await photosAggregate.insert(ctx, doc3!);
@@ -289,6 +299,254 @@ describe("TableAggregate with namespace", () => {
       });
 
       expect(vacationCountWithBounds).toBe(2);
+    });
+
+    test("should respect bounds when provided with namespace", async () => {
+      // Use a custom schema with an explicit score field for predictable sorting
+      const testSchema = defineSchema({
+        boundsTestPhotos: defineTable({
+          album: v.string(),
+          url: v.string(),
+          score: v.number(), // Explicit sort key we can control
+        }),
+      });
+
+      const testT = convexTest(testSchema, modules);
+      testT.registerComponent("aggregate", componentSchema, componentModules);
+
+      type PhotosAggregateType = {
+        Namespace: string;
+        Key: number;
+        DataModel: GenericDataModel;
+        TableName: "boundsTestPhotos";
+      };
+
+      const photosAggregate = new TableAggregate<PhotosAggregateType>(
+        components.aggregate,
+        {
+          namespace: (doc) => (doc as { album: string }).album,
+          sortKey: (doc) => (doc as { score: number }).score, // Use explicit score
+        }
+      );
+
+      // Insert photos with explicit scores for predictable bounds testing
+      await testT.run(async (ctx) => {
+        const doc1 = { album: "vacation", url: "photo1.jpg", score: 10 };
+        const doc2 = { album: "vacation", url: "photo2.jpg", score: 20 };
+        const doc3 = { album: "vacation", url: "photo3.jpg", score: 30 };
+
+        const id1 = await ctx.db.insert("boundsTestPhotos", doc1);
+        const id2 = await ctx.db.insert("boundsTestPhotos", doc2);
+        const id3 = await ctx.db.insert("boundsTestPhotos", doc3);
+
+        const insertedDoc1 = await ctx.db.get(id1);
+        const insertedDoc2 = await ctx.db.get(id2);
+        const insertedDoc3 = await ctx.db.get(id3);
+
+        await photosAggregate.insert(ctx, insertedDoc1!);
+        await photosAggregate.insert(ctx, insertedDoc2!);
+        await photosAggregate.insert(ctx, insertedDoc3!);
+      });
+
+      // Count all photos in vacation album (no bounds)
+      const totalCount = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+        });
+      });
+      expect(totalCount).toBe(3);
+
+      // Count with lower bound - should exclude first photo (score 10)
+      const countFromSecond = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+          bounds: {
+            lower: { key: 20, inclusive: true },
+          },
+        });
+      });
+      expect(countFromSecond).toBe(2); // photos with score 20 and 30
+
+      // Count with upper bound - should exclude third photo (score 30)
+      const countUpToSecond = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+          bounds: {
+            upper: { key: 20, inclusive: true },
+          },
+        });
+      });
+      expect(countUpToSecond).toBe(2); // photos with score 10 and 20
+
+      // Count with both bounds - should only include middle photo
+      const countMiddleOnly = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+          bounds: {
+            lower: { key: 20, inclusive: true },
+            upper: { key: 20, inclusive: true },
+          },
+        });
+      });
+      expect(countMiddleOnly).toBe(1); // only photo with score 20
+
+      // Test simple lower bound
+      const countWithLowerBound = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+          bounds: {
+            lower: { key: 25, inclusive: true }, // Should only include photo with score 30
+          },
+        });
+      });
+      expect(countWithLowerBound).toBe(1); // Only photo with score 30
+
+      // Test upper bound
+      const countWithUpperBound = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+          bounds: {
+            upper: { key: 15, inclusive: true }, // Should only include photo with score 10
+          },
+        });
+      });
+      expect(countWithUpperBound).toBe(1); // Only photo with score 10
+    });
+
+    test("comprehensive bounds and namespace test", async () => {
+      // Test that demonstrates both optional bounds and bounds-based filtering
+      const testSchema = defineSchema({
+        comprehensiveTestPhotos: defineTable({
+          album: v.string(),
+          url: v.string(),
+          score: v.number(),
+        }),
+      });
+
+      const testT = convexTest(testSchema, modules);
+      testT.registerComponent("aggregate", componentSchema, componentModules);
+
+      type PhotosAggregateType = {
+        Namespace: string;
+        Key: number;
+        DataModel: GenericDataModel;
+        TableName: "comprehensiveTestPhotos";
+      };
+
+      const photosAggregate = new TableAggregate<PhotosAggregateType>(
+        components.aggregate,
+        {
+          namespace: (doc) => (doc as { album: string }).album,
+          sortKey: (doc) => (doc as { score: number }).score,
+        }
+      );
+
+      // Insert test data across multiple namespaces
+      await testT.run(async (ctx) => {
+        // Vacation album photos
+        const vacation1 = { album: "vacation", url: "v1.jpg", score: 5 };
+        const vacation2 = { album: "vacation", url: "v2.jpg", score: 15 };
+        const vacation3 = { album: "vacation", url: "v3.jpg", score: 25 };
+
+        // Family album photos
+        const family1 = { album: "family", url: "f1.jpg", score: 10 };
+        const family2 = { album: "family", url: "f2.jpg", score: 20 };
+
+        for (const doc of [vacation1, vacation2, vacation3, family1, family2]) {
+          const id = await ctx.db.insert("comprehensiveTestPhotos", doc);
+          const insertedDoc = await ctx.db.get(id);
+          await photosAggregate.insert(ctx, insertedDoc!);
+        }
+      });
+
+      // Test: Count all vacation photos (no bounds required!)
+      const allVacationCount = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+        });
+      });
+      expect(allVacationCount).toBe(3);
+
+      // Test: Count all family photos (no bounds required!)
+      const allFamilyCount = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "family",
+        });
+      });
+      expect(allFamilyCount).toBe(2);
+
+      // Test: Count vacation photos with bounds - only high scores
+      const highScoreVacationCount = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "vacation",
+          bounds: {
+            lower: { key: 20, inclusive: true }, // score >= 20
+          },
+        });
+      });
+      expect(highScoreVacationCount).toBe(1); // Only score 25
+
+      // Test: Count family photos with bounds - only low scores
+      const lowScoreFamilyCount = await testT.run(async (ctx) => {
+        return await photosAggregate.count(ctx, {
+          namespace: "family",
+          bounds: {
+            upper: { key: 15, inclusive: true }, // score <= 15
+          },
+        });
+      });
+      expect(lowScoreFamilyCount).toBe(1); // Only score 10
+    });
+
+    test("should isolate bounds within different namespaces", async () => {
+      await t.run(async (ctx) => {
+        // Insert photo in vacation album with score 15
+        const vacationDoc = {
+          album: "vacation",
+          url: "vacation1.jpg",
+          score: 15,
+        };
+        const vacationId = await ctx.db.insert("photos", vacationDoc);
+        const insertedVacationDoc = await ctx.db.get(vacationId);
+        await aggregateWithNamespace.insert(ctx, insertedVacationDoc!);
+
+        // Insert photo in family album with score 25
+        const familyDoc = { album: "family", url: "family1.jpg", score: 25 };
+        const familyId = await ctx.db.insert("photos", familyDoc);
+        const insertedFamilyDoc = await ctx.db.get(familyId);
+        await aggregateWithNamespace.insert(ctx, insertedFamilyDoc!);
+      });
+
+      // Using bounds that would exclude family photo shouldn't affect family namespace count
+      const familyCount = await t.run(async (ctx) => {
+        return await aggregateWithNamespace.count(ctx, {
+          namespace: "family",
+          bounds: {
+            upper: { key: 20, inclusive: true }, // Family photo has score 25, so this excludes it
+          },
+        });
+      });
+      expect(familyCount).toBe(0);
+
+      // Count family photos without bounds should still work
+      const familyCountNoBounds = await t.run(async (ctx) => {
+        return await aggregateWithNamespace.count(ctx, {
+          namespace: "family",
+        });
+      });
+      expect(familyCountNoBounds).toBe(1);
+
+      // Count vacation photos with bounds that would include family photo score
+      const vacationCount = await t.run(async (ctx) => {
+        return await aggregateWithNamespace.count(ctx, {
+          namespace: "vacation",
+          bounds: {
+            upper: { key: 30, inclusive: true }, // Would include family score, but family is different namespace
+          },
+        });
+      });
+      // Should be 1 - only the vacation photo, not affected by family photo
+      expect(vacationCount).toBe(1);
     });
   });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -872,8 +872,9 @@ export function btreeItemToAggregateItem<K extends Key, ID extends string>({
 export type NamespacedArgs<Args, Namespace> =
   | (Args & { namespace: Namespace })
   | (Namespace extends undefined ? Args : never);
+
 export type NamespacedOpts<Opts, Namespace> =
-  | [{ namespace: Namespace } & Partial<Opts>]
+  | [{ namespace: Namespace } & Opts]
   | (undefined extends Namespace ? [Opts?] : never);
 
 function namespaceFromArg<Args extends object, Namespace>(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -66,7 +66,7 @@ export class Aggregate<
    */
   async count(
     ctx: RunQueryCtx,
-    ...opts: NamespacedOpts<{ bounds: Bounds<K, ID> }, Namespace>
+    ...opts: NamespacedOpts<{ bounds?: Bounds<K, ID> }, Namespace>
   ): Promise<number> {
     const { count } = await ctx.runQuery(
       this.component.btree.aggregateBetween,
@@ -82,7 +82,7 @@ export class Aggregate<
    */
   async sum(
     ctx: RunQueryCtx,
-    ...opts: NamespacedOpts<{ bounds: Bounds<K, ID> }, Namespace>
+    ...opts: NamespacedOpts<{ bounds?: Bounds<K, ID> }, Namespace>
   ): Promise<number> {
     const { sum } = await ctx.runQuery(this.component.btree.aggregateBetween, {
       ...boundsToPositions(opts[0]?.bounds),
@@ -181,7 +181,7 @@ export class Aggregate<
    */
   async min(
     ctx: RunQueryCtx,
-    ...opts: NamespacedOpts<{ bounds: Bounds<K, ID> }, Namespace>
+    ...opts: NamespacedOpts<{ bounds?: Bounds<K, ID> }, Namespace>
   ): Promise<Item<K, ID> | null> {
     const { page } = await this.paginate(ctx, {
       namespace: namespaceFromOpts(opts),
@@ -196,7 +196,7 @@ export class Aggregate<
    */
   async max(
     ctx: RunQueryCtx,
-    ...opts: NamespacedOpts<{ bounds: Bounds<K, ID> }, Namespace>
+    ...opts: NamespacedOpts<{ bounds?: Bounds<K, ID> }, Namespace>
   ): Promise<Item<K, ID> | null> {
     const { page } = await this.paginate(ctx, {
       namespace: namespaceFromOpts(opts),
@@ -211,7 +211,7 @@ export class Aggregate<
    */
   async random(
     ctx: RunQueryCtx,
-    ...opts: NamespacedOpts<{ bounds: Bounds<K, ID> }, Namespace>
+    ...opts: NamespacedOpts<{ bounds?: Bounds<K, ID> }, Namespace>
   ): Promise<Item<K, ID> | null> {
     const count = await this.count(ctx, ...opts);
     if (count === 0) {
@@ -873,7 +873,7 @@ export type NamespacedArgs<Args, Namespace> =
   | (Args & { namespace: Namespace })
   | (Namespace extends undefined ? Args : never);
 export type NamespacedOpts<Opts, Namespace> =
-  | [{ namespace: Namespace } & Opts]
+  | [{ namespace: Namespace } & Partial<Opts>]
   | (undefined extends Namespace ? [Opts?] : never);
 
 function namespaceFromArg<Args extends object, Namespace>(


### PR DESCRIPTION
Right now if you use a namespaced table aggregate you are forced to include a bounds. 

As per this issue it is desired that bounds be optional: https://github.com/get-convex/aggregate/issues/22

This PR addresses that.

I have added some more tests to ensure that bounds and non bounds use cases still work for count.

This PR is based upon #34 so has all the changes from that PR too. 