### PR TITLE
Add sumBatch() method to complete batch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,10 +506,9 @@ aggregates based on the diff of these two paginated data streams.
 
 For improved performance when making multiple similar queries, the Aggregate component provides batch versions of common operations:
 
-- `batchCount()` - Count items for multiple bounds in a single call
-- `batchAt()` - Return items at multiple offsets in a single call
-
-If you want more batched functions, file a [GitHub issue](https://github.com/get-convex/aggregate/issues)
+- `countBatch()` - Count items for multiple bounds in a single call
+- `sumBatch()` - Sum items for multiple bounds in a single call
+- `atBatch()` - Return items at multiple offsets in a single call
 
 These batch functions are significantly more efficient than making individual calls because they:
 
@@ -526,9 +525,11 @@ const counts = await Promise.all([
 ]);
 
 // Use the batch equivalent for better performance:
-const counts = await aggregate.batchCount(ctx, {
-  queries: [{ bounds: bounds1 }, { bounds: bounds2 }, { bounds: bounds3 }],
-});
+const counts = await aggregate.countBatch(ctx, [
+  { bounds: bounds1 },
+  { bounds: bounds2 },
+  { bounds: bounds3 }
+]);
 ```
 
 The batch functions accept arrays of query parameters and return arrays of results in the same order, making them drop-in replacements for multiple individual calls while providing better performance characteristics.


### PR DESCRIPTION
As requested here https://github.com/get-convex/aggregate/issues/31
This has been tested with a project running many sums concurrently, now updated to use the new sumBatch. The project is using many smaller namespaces with rootLazy set to false with maxNodes set very high (as these aggregates are calculated once so reads need to be quick but not writes).

Claude code generated description:

Adds sumBatch() for efficient batched sum queries across multiple bounds. Implementation mirrors countBatch() pattern, reusing existing aggregateBetweenBatch infrastructure.

- Add sumBatch() method to Aggregate class
- Add comprehensive tests for empty tables, multiple ranges, and exclusive bounds
- Update README to document all batch methods (countBatch, sumBatch, atBatch)
- Fix README example to use correct API naming

All tests passing (39/39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
