### PR TITLE
Reece/add pending ops schema and assert no pending ops guards

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -100,6 +100,7 @@ export class Aggregate<
       {
         ...boundsToPositions(opts[0]?.bounds),
         namespace: namespaceFromOpts(opts),
+        stale: opts[0]?.stale,
       },
       opts[0]?.stale,
     );
@@ -127,6 +128,7 @@ export class Aggregate<
       this.component.btree.aggregateBetweenBatch,
       {
         queries: queryArgs,
+        stale: opts?.stale,
       },
       opts?.stale,
     );
@@ -149,6 +151,7 @@ export class Aggregate<
       {
         ...boundsToPositions(opts[0]?.bounds),
         namespace: namespaceFromOpts(opts),
+        stale: opts[0]?.stale,
       },
       opts[0]?.stale,
     );
@@ -176,6 +179,7 @@ export class Aggregate<
       this.component.btree.aggregateBetweenBatch,
       {
         queries: queryArgs,
+        stale: opts?.stale,
       },
       opts?.stale,
     );
@@ -206,6 +210,7 @@ export class Aggregate<
           offset: -offset - 1,
           namespace: namespaceFromOpts(opts),
           ...boundsToPositions(opts[0]?.bounds),
+          stale: opts[0]?.stale,
         },
         opts[0]?.stale,
       );
@@ -218,6 +223,7 @@ export class Aggregate<
         offset,
         namespace: namespaceFromOpts(opts),
         ...boundsToPositions(opts[0]?.bounds),
+        stale: opts[0]?.stale,
       },
       opts[0]?.stale,
     );
@@ -245,6 +251,7 @@ export class Aggregate<
       this.component.btree.atOffsetBatch,
       {
         queries: queryArgs,
+        stale: opts?.stale,
       },
       opts?.stale,
     );
@@ -284,6 +291,7 @@ export class Aggregate<
           }),
           k2,
           namespace: namespaceFromOpts(opts),
+          stale: opts[0]?.stale,
         },
         opts[0]?.stale,
       );
@@ -299,6 +307,7 @@ export class Aggregate<
         }),
         k1,
         namespace: namespaceFromOpts(opts),
+        stale: opts[0]?.stale,
       },
       opts[0]?.stale,
     );
@@ -429,6 +438,7 @@ export class Aggregate<
         cursor: opts[0]?.cursor,
         order,
         limit: pageSize,
+        stale: opts[0]?.stale,
       },
       opts[0]?.stale,
     );
@@ -638,6 +648,7 @@ export class Aggregate<
       {
         cursor,
         limit: pageSize,
+        stale,
       },
       stale,
     );

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -27,28 +27,43 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       aggregateBetween: FunctionReference<
         "query",
         "internal",
-        { k1?: any; k2?: any; namespace?: any },
+        { k1?: any; k2?: any; namespace?: any; stale?: boolean },
         { count: number; sum: number },
         Name
       >;
       aggregateBetweenBatch: FunctionReference<
         "query",
         "internal",
-        { queries: Array<{ k1?: any; k2?: any; namespace?: any }> },
+        {
+          queries: Array<{ k1?: any; k2?: any; namespace?: any }>;
+          stale?: boolean;
+        },
         Array<{ count: number; sum: number }>,
         Name
       >;
       atNegativeOffset: FunctionReference<
         "query",
         "internal",
-        { k1?: any; k2?: any; namespace?: any; offset: number },
+        {
+          k1?: any;
+          k2?: any;
+          namespace?: any;
+          offset: number;
+          stale?: boolean;
+        },
         { k: any; s: number; v: any },
         Name
       >;
       atOffset: FunctionReference<
         "query",
         "internal",
-        { k1?: any; k2?: any; namespace?: any; offset: number },
+        {
+          k1?: any;
+          k2?: any;
+          namespace?: any;
+          offset: number;
+          stale?: boolean;
+        },
         { k: any; s: number; v: any },
         Name
       >;
@@ -62,6 +77,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             namespace?: any;
             offset: number;
           }>;
+          stale?: boolean;
         },
         Array<{ k: any; s: number; v: any }>,
         Name
@@ -69,21 +85,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       get: FunctionReference<
         "query",
         "internal",
-        { key: any; namespace?: any },
+        { key: any; namespace?: any; stale?: boolean },
         null | { k: any; s: number; v: any },
         Name
       >;
       offset: FunctionReference<
         "query",
         "internal",
-        { k1?: any; key: any; namespace?: any },
+        { k1?: any; key: any; namespace?: any; stale?: boolean },
         number,
         Name
       >;
       offsetUntil: FunctionReference<
         "query",
         "internal",
-        { k2?: any; key: any; namespace?: any },
+        { k2?: any; key: any; namespace?: any; stale?: boolean },
         number,
         Name
       >;
@@ -97,6 +113,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           limit: number;
           namespace?: any;
           order: "asc" | "desc";
+          stale?: boolean;
         },
         {
           cursor: string;
@@ -108,14 +125,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       paginateNamespaces: FunctionReference<
         "query",
         "internal",
-        { cursor?: string; limit: number },
+        { cursor?: string; limit: number; stale?: boolean },
         { cursor: string; isDone: boolean; page: Array<any> },
         Name
       >;
       validate: FunctionReference<
         "query",
         "internal",
-        { namespace?: any },
+        { namespace?: any; stale?: boolean },
         any,
         Name
       >;

--- a/src/component/btree.test.ts
+++ b/src/component/btree.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { convexTest } from "convex-test";
+import { convexTest, type TestConvex } from "convex-test";
 import schema, { type Item } from "./schema.js";
 import { modules } from "./setup.test.js";
 import { test as fcTest, fc } from "@fast-check/vitest";
 import {
   atOffsetHandler,
   aggregateBetweenHandler,
+  assertNoPendingOperations,
   deleteHandler,
   getHandler,
   insertHandler,
@@ -19,6 +20,7 @@ import {
   aggregateBetweenBatchHandler,
   atOffsetBatchHandler,
 } from "./btree.js";
+import { api } from "./_generated/api.js";
 import { compareValues } from "./compare.js";
 import { arbitraryValue } from "./arbitrary.helpers.js";
 import { ConvexError, convexToJson, jsonToConvex } from "convex/values";
@@ -793,4 +795,44 @@ describe("btree matches simpler impl", () => {
       });
     },
   );
+});
+
+describe("stale / pendingOperations", () => {
+  function setupTest(): TestConvex<typeof schema> {
+    return convexTest(schema, modules);
+  }
+
+  test("assertNoPendingOperations throws iff pendingOperations is non-empty", async () => {
+    const t = setupTest();
+    await t.run(async (ctx) => {
+      await assertNoPendingOperations(ctx);
+      await ctx.db.insert("pendingOperations", {
+        commitTs: 1n,
+        operations: [{ type: "delete", key: 1 }],
+      });
+      await expect(assertNoPendingOperations(ctx)).rejects.toThrow(/PENDING_OPERATIONS/);
+    });
+  });
+
+  test("read query guards on pendingOperations unless stale", async () => {
+    const t = setupTest();
+    await t.run(async (ctx) => {
+      await getOrCreateTree(ctx.db, undefined, 4, false);
+      await insertHandler(ctx, { key: 1, value: "a" });
+      await insertHandler(ctx, { key: 2, value: "b" });
+      await ctx.db.insert("pendingOperations", {
+        commitTs: 1n,
+        operations: [{ type: "insert", key: 3, value: "c" }],
+      });
+    });
+    // Non-stale read throws while the queue is non-empty.
+    await expect(t.query(api.btree.aggregateBetween, {})).rejects.toThrow(
+      /PENDING_OPERATIONS/,
+    );
+    // Stale read skips the guard and returns the current tree state.
+    const { count } = await t.query(api.btree.aggregateBetween, {
+      stale: true,
+    });
+    expect(count).toEqual(2);
+  });
 });

--- a/src/component/btree.ts
+++ b/src/component/btree.ts
@@ -42,6 +42,17 @@ function log(s: string) {
   }
 }
 
+export async function assertNoPendingOperations(ctx: { db: DatabaseReader }) {
+  const pending = await ctx.db.query("pendingOperations").first();
+  if (pending) {
+    throw new ConvexError({
+      code: "PENDING_OPERATIONS",
+      message:
+        "Cannot synchronously read or write to the aggregate while there are async updates enqueued.",
+    });
+  }
+}
+
 export async function insertHandler(
   ctx: { db: DatabaseWriter },
   args: { key: Key; value: Value; summand?: number; namespace?: Namespace },
@@ -170,8 +181,11 @@ export async function replaceOrInsertHandler(
 }
 
 export const validate = query({
-  args: { namespace: v.optional(v.any()) },
-  handler: validateTree,
+  args: { namespace: v.optional(v.any()), stale: v.optional(v.boolean()) },
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return validateTree(ctx, args);
+  },
 });
 
 export async function validateTree(
@@ -370,9 +384,13 @@ export const aggregateBetween = query({
     k1: v.optional(v.any()),
     k2: v.optional(v.any()),
     namespace: v.optional(v.any()),
+    stale: v.optional(v.boolean()),
   },
   returns: aggregate,
-  handler: aggregateBetweenHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return aggregateBetweenHandler(ctx, args);
+  },
 });
 
 async function aggregateBetweenInNode(
@@ -408,9 +426,16 @@ export async function getHandler(
 }
 
 export const get = query({
-  args: { key: v.any(), namespace: v.optional(v.any()) },
+  args: {
+    key: v.any(),
+    namespace: v.optional(v.any()),
+    stale: v.optional(v.boolean()),
+  },
   returns: v.union(v.null(), itemValidator),
-  handler: getHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return getHandler(ctx, args);
+  },
 });
 
 async function getInNode(
@@ -442,9 +467,13 @@ export const atOffset = query({
     k1: v.optional(v.any()),
     k2: v.optional(v.any()),
     namespace: v.optional(v.any()),
+    stale: v.optional(v.boolean()),
   },
   returns: itemValidator,
-  handler: atOffsetHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return atOffsetHandler(ctx, args);
+  },
 });
 
 export async function atOffsetHandler(
@@ -470,9 +499,13 @@ export const atNegativeOffset = query({
     k1: v.optional(v.any()),
     k2: v.optional(v.any()),
     namespace: v.optional(v.any()),
+    stale: v.optional(v.boolean()),
   },
   returns: itemValidator,
-  handler: atNegativeOffsetHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return atNegativeOffsetHandler(ctx, args);
+  },
 });
 
 export async function atNegativeOffsetHandler(
@@ -517,9 +550,13 @@ export const offset = query({
     key: v.any(),
     k1: v.optional(v.any()),
     namespace: v.optional(v.any()),
+    stale: v.optional(v.boolean()),
   },
   returns: v.number(),
-  handler: offsetHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return offsetHandler(ctx, args);
+  },
 });
 
 export async function offsetUntilHandler(
@@ -541,9 +578,13 @@ export const offsetUntil = query({
     key: v.any(),
     k2: v.optional(v.any()),
     namespace: v.optional(v.any()),
+    stale: v.optional(v.boolean()),
   },
   returns: v.number(),
-  handler: offsetUntilHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return offsetUntilHandler(ctx, args);
+  },
 });
 
 async function deleteFromNode(
@@ -1074,13 +1115,17 @@ export const paginate = query({
     k1: v.optional(v.any()),
     k2: v.optional(v.any()),
     namespace: v.optional(v.any()),
+    stale: v.optional(v.boolean()),
   },
   returns: v.object({
     page: v.array(itemValidator),
     cursor: v.string(),
     isDone: v.boolean(),
   }),
-  handler: paginateHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return paginateHandler(ctx, args);
+  },
 });
 
 export async function paginateHandler(
@@ -1189,13 +1234,17 @@ export const paginateNamespaces = query({
   args: {
     limit: v.number(),
     cursor: v.optional(v.string()),
+    stale: v.optional(v.boolean()),
   },
   returns: v.object({
     page: v.array(v.any()),
     cursor: v.string(),
     isDone: v.boolean(),
   }),
-  handler: paginateNamespacesHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return paginateNamespacesHandler(ctx, args);
+  },
 });
 
 export async function paginateNamespacesHandler(
@@ -1235,9 +1284,13 @@ export const aggregateBetweenBatch = query({
         namespace: v.optional(v.any()),
       }),
     ),
+    stale: v.optional(v.boolean()),
   },
   returns: v.array(aggregate),
-  handler: aggregateBetweenBatchHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return aggregateBetweenBatchHandler(ctx, args);
+  },
 });
 
 export async function aggregateBetweenBatchHandler(
@@ -1259,9 +1312,13 @@ export const atOffsetBatch = query({
         namespace: v.optional(v.any()),
       }),
     ),
+    stale: v.optional(v.boolean()),
   },
   returns: v.array(itemValidator),
-  handler: atOffsetBatchHandler,
+  handler: async (ctx, { stale, ...args }) => {
+    if (!stale) await assertNoPendingOperations(ctx);
+    return atOffsetBatchHandler(ctx, args);
+  },
 });
 
 // Differs from atOffset in that it handles negative offsets.

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { mutation } from "./_generated/server.js";
 import {
+  assertNoPendingOperations,
   DEFAULT_MAX_NODE_SIZE,
   deleteHandler,
   deleteIfExistsHandler,
@@ -61,14 +62,20 @@ export const insert = mutation({
     namespace: v.optional(v.any()),
   },
   returns: v.null(),
-  handler: insertHandler,
+  handler: async (ctx, args) => {
+    await assertNoPendingOperations(ctx);
+    await insertHandler(ctx, args);
+  },
 });
 
 // delete is a keyword, hence the underscore.
 export const delete_ = mutation({
   args: { key: v.any(), namespace: v.optional(v.any()) },
   returns: v.null(),
-  handler: deleteHandler,
+  handler: async (ctx, args) => {
+    await assertNoPendingOperations(ctx);
+    await deleteHandler(ctx, args);
+  },
 });
 
 export const replace = mutation({
@@ -81,12 +88,18 @@ export const replace = mutation({
     newNamespace: v.optional(v.any()),
   },
   returns: v.null(),
-  handler: replaceHandler,
+  handler: async (ctx, args) => {
+    await assertNoPendingOperations(ctx);
+    await replaceHandler(ctx, args);
+  },
 });
 
 export const deleteIfExists = mutation({
   args: { key: v.any(), namespace: v.optional(v.any()) },
-  handler: deleteIfExistsHandler,
+  handler: async (ctx, args) => {
+    await assertNoPendingOperations(ctx);
+    await deleteIfExistsHandler(ctx, args);
+  },
 });
 
 export const replaceOrInsert = mutation({
@@ -98,7 +111,10 @@ export const replaceOrInsert = mutation({
     namespace: v.optional(v.any()),
     newNamespace: v.optional(v.any()),
   },
-  handler: replaceOrInsertHandler,
+  handler: async (ctx, args) => {
+    await assertNoPendingOperations(ctx);
+    await replaceOrInsertHandler(ctx, args);
+  },
 });
 
 /**
@@ -115,6 +131,7 @@ export const clear = mutation({
   },
   returns: v.null(),
   handler: async (ctx, { maxNodeSize, rootLazy, namespace }) => {
+    await assertNoPendingOperations(ctx);
     const tree = await getTree(ctx.db, namespace);
     let existingRootLazy = true;
     let existingMaxNodeSize = DEFAULT_MAX_NODE_SIZE;

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -29,6 +29,46 @@ export const aggregate = v.object({
 
 export type Aggregate = Infer<typeof aggregate>;
 
+export const vOperation = v.union(
+  v.object({
+    type: v.literal("insert"),
+    key: v.any(),
+    value: v.any(),
+    summand: v.optional(v.number()),
+    namespace: v.optional(v.any()),
+  }),
+  v.object({
+    type: v.literal("delete"),
+    key: v.any(),
+    namespace: v.optional(v.any()),
+  }),
+  v.object({
+    type: v.literal("replace"),
+    currentKey: v.any(),
+    newKey: v.any(),
+    value: v.any(),
+    summand: v.optional(v.number()),
+    namespace: v.optional(v.any()),
+    newNamespace: v.optional(v.any()),
+  }),
+  v.object({
+    type: v.literal("deleteIfExists"),
+    key: v.any(),
+    namespace: v.optional(v.any()),
+  }),
+  v.object({
+    type: v.literal("replaceOrInsert"),
+    currentKey: v.any(),
+    newKey: v.any(),
+    value: v.any(),
+    summand: v.optional(v.number()),
+    namespace: v.optional(v.any()),
+    newNamespace: v.optional(v.any()),
+  }),
+);
+
+export type Operation = Infer<typeof vOperation>;
+
 export default defineSchema({
   // One per namespace
   btree: defineTable({
@@ -41,4 +81,8 @@ export default defineSchema({
     subtrees: v.array(v.id("btreeNode")),
     aggregate: v.optional(aggregate),
   }),
+  pendingOperations: defineTable({
+    commitTs: v.commitTs(),
+    operations: v.array(vOperation),
+  }).index("by_commitTs", ["commitTs"]),
 });


### PR DESCRIPTION
Add the `pendingOps` table to the schema, and add a guard to all aggregate operations to throw an error if `pendingOps` is not empty and `lazy` is not true. 