### PR TITLE
add an enqueueBatch mutation to the component

### DIFF
--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -244,6 +244,43 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         null,
         Name
       >;
+      enqueueBatch: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          operations: Array<
+            | {
+                key: any;
+                namespace?: any;
+                summand?: number;
+                type: "insert";
+                value: any;
+              }
+            | { key: any; namespace?: any; type: "delete" }
+            | {
+                currentKey: any;
+                namespace?: any;
+                newKey: any;
+                newNamespace?: any;
+                summand?: number;
+                type: "replace";
+                value: any;
+              }
+            | { key: any; namespace?: any; type: "deleteIfExists" }
+            | {
+                currentKey: any;
+                namespace?: any;
+                newKey: any;
+                newNamespace?: any;
+                summand?: number;
+                type: "replaceOrInsert";
+                value: any;
+              }
+          >;
+        },
+        null,
+        Name
+      >;
       init: FunctionReference<
         "mutation",
         "internal",

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -11,7 +11,7 @@ import {
   replaceHandler,
   replaceOrInsertHandler,
 } from "./btree.js";
-import { enqueueOperation } from "./worker.js";
+import { enqueueOperations } from "./worker.js";
 import { internal } from "./_generated/api.js";
 import { vOperation } from "./schema.js";
 
@@ -125,7 +125,17 @@ export const enqueue = mutation({
   },
   returns: v.null(),
   handler: async (ctx, { operation }) => {
-    await enqueueOperation(ctx, operation);
+    await enqueueOperations(ctx, [operation]);
+  },
+});
+
+export const enqueueBatch = mutation({
+  args: {
+    operations: v.array(vOperation),
+  },
+  returns: v.null(),
+  handler: async (ctx, { operations }) => {
+    await enqueueOperations(ctx, operations);
   },
 });
 

--- a/src/component/worker.test.ts
+++ b/src/component/worker.test.ts
@@ -9,7 +9,11 @@ import {
 } from "vitest";
 import type { TestConvex } from "convex-test";
 import type { TransactionMetrics } from "convex/server";
-import { type CommitTsPlaceholder, getConvexSize } from "convex/values";
+import {
+  type CommitTsPlaceholder,
+  getConvexSize,
+  getDocumentSize,
+} from "convex/values";
 import schema, { type Operation } from "./schema.js";
 import { initConvexTest } from "./setup.test.js";
 import {
@@ -21,7 +25,8 @@ import {
 } from "./btree.js";
 import {
   BATCH_MAX_OPERATIONS,
-  enqueueOperation,
+  MAX_BYTES_PER_ENTRY,
+  enqueueOperations,
   hasHeadroomToFinish,
   MAX_OPERATIONS_PER_ENTRY,
   OPS_WORKER_NAME,
@@ -52,7 +57,7 @@ async function enqueue(
 ): Promise<bigint> {
   const commitTs = await t.run(async (ctx) => {
     for (const operation of operations) {
-      await enqueueOperation(ctx, operation);
+      await enqueueOperations(ctx, [operation]);
     }
     // Resolved on the way out, once the transaction has a timestamp.
     return ctx.db.vars.commitTs;
@@ -139,6 +144,19 @@ async function pendingOperationTimestamps(
 }
 
 describe("enqueue", () => {
+  function insertOp(i: number, bytes: number): Operation {
+    return { type: "insert", key: "k".repeat(bytes), value: `v${i}` };
+  }
+
+  const emptyEntryBytes = getDocumentSize({ commitTs: 0n, operations: [] });
+
+  function maxInsertOpsPerEntry(bytes: number): number {
+    return Math.floor(
+      (MAX_BYTES_PER_ENTRY - emptyEntryBytes) /
+        getConvexSize(insertOp(0, bytes)),
+    );
+  }
+
   test("one transaction's operations share a row keyed by its commitTs", async () => {
     const t = initConvexTest();
     // Two operations in one transaction share a row; a later transaction gets
@@ -185,6 +203,117 @@ describe("enqueue", () => {
       ]);
       expect(rows.flatMap((r) => r.operations)).toEqual(inserts(0, queued));
     });
+  });
+
+  test("a batch fills the transaction's newest row before spilling onto another", async () => {
+    const t = initConvexTest();
+    const commitTs = await t.run(async (ctx) => {
+      await enqueueOperations(ctx, inserts(0, 1));
+      await enqueueOperations(ctx, inserts(1, MAX_OPERATIONS_PER_ENTRY + 1));
+      return ctx.db.vars.commitTs;
+    });
+    const queued = MAX_OPERATIONS_PER_ENTRY + 2;
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query("pendingOperations").collect();
+      expect(rows.map((r) => expectBigint(r.commitTs))).toEqual([
+        expectBigint(commitTs),
+        expectBigint(commitTs),
+      ]);
+      expect(rows.map((r) => r.operations.length)).toEqual([
+        MAX_OPERATIONS_PER_ENTRY,
+        2,
+      ]);
+      expect(rows.flatMap((r) => r.operations)).toEqual(inserts(0, queued));
+    });
+  });
+
+  test("a batch larger than two rows spills onto as many rows as it needs", async () => {
+    const t = initConvexTest();
+    const queued = 2 * MAX_OPERATIONS_PER_ENTRY + 1;
+    await t.run(async (ctx) => {
+      await enqueueOperations(ctx, inserts(0, queued));
+    });
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query("pendingOperations").collect();
+      expect(rows.map((r) => r.operations.length)).toEqual([
+        MAX_OPERATIONS_PER_ENTRY,
+        MAX_OPERATIONS_PER_ENTRY,
+        1,
+      ]);
+      expect(rows.flatMap((r) => r.operations)).toEqual(inserts(0, queued));
+    });
+  });
+
+  test("a batch splits rows that would exceed the document size limit", async () => {
+    const t = initConvexTest();
+    // A quarter of a row each, so bytes run out well before
+    // MAX_OPERATIONS_PER_ENTRY does.
+    const bytes = MAX_BYTES_PER_ENTRY / 4;
+    const fit = maxInsertOpsPerEntry(bytes);
+    expect(fit).toBeGreaterThan(0);
+    expect(fit).toBeLessThan(MAX_OPERATIONS_PER_ENTRY);
+    const operations = Array.from({ length: fit + 1 }, (_, i) =>
+      insertOp(i, bytes),
+    );
+    await t.run(async (ctx) => {
+      await enqueueOperations(ctx, operations);
+    });
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query("pendingOperations").collect();
+      expect(rows.map((r) => r.operations.length)).toEqual([fit, 1]);
+      expect(rows.flatMap((r) => r.operations)).toEqual(operations);
+      for (const row of rows) {
+        expect(getDocumentSize(row)).toBeLessThanOrEqual(MAX_BYTES_PER_ENTRY);
+      }
+    });
+  });
+
+  test("a batch stops appending to a row that has no room left in bytes", async () => {
+    const t = initConvexTest();
+    const bytes = MAX_BYTES_PER_ENTRY / 4;
+    const fit = maxInsertOpsPerEntry(bytes);
+    // One operation already in the row, then a row's worth behind it: all but
+    // the last fill the row up, and that last one spills onto a new one.
+    const operations = Array.from({ length: fit }, (_, i) =>
+      insertOp(i + 1, bytes),
+    );
+    await t.run(async (ctx) => {
+      await enqueueOperations(ctx, [insertOp(0, bytes)]);
+      await enqueueOperations(ctx, operations);
+    });
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query("pendingOperations").collect();
+      expect(rows.map((r) => r.operations.length)).toEqual([fit, 1]);
+      expect(rows.flatMap((r) => r.operations)).toEqual([
+        insertOp(0, bytes),
+        ...operations,
+      ]);
+    });
+  });
+
+  test("an operation too large to fit anywhere does not stall the batch", async () => {
+    const t = initConvexTest();
+    const bytes = MAX_BYTES_PER_ENTRY / 4;
+    const operations = [
+      insertOp(0, bytes),
+      insertOp(1, MAX_BYTES_PER_ENTRY + 1),
+      insertOp(2, bytes),
+    ];
+    await t.run(async (ctx) => {
+      await enqueueOperations(ctx, operations);
+    });
+    await t.run(async (ctx) => {
+      const rows = await ctx.db.query("pendingOperations").collect();
+      expect(rows.flatMap((r) => r.operations)).toEqual(operations);
+    });
+  });
+
+  test("an empty batch enqueues nothing", async () => {
+    const t = initConvexTest();
+    await t.run(async (ctx) => {
+      await enqueueOperations(ctx, []);
+    });
+    expect(await pendingOperationTimestamps(t)).toEqual([]);
   });
 });
 

--- a/src/component/worker.ts
+++ b/src/component/worker.ts
@@ -1,6 +1,12 @@
 import { defineBatchWorkerValidators, ping } from "@convex-dev/batch-worker";
-import { ConvexError, getConvexSize, type Infer, v } from "convex/values";
-import type { TransactionMetrics } from "convex/server";
+import {
+  ConvexError,
+  getConvexSize,
+  getDocumentSize,
+  type Infer,
+  v,
+} from "convex/values";
+import type { TransactionMetrics, WithoutSystemFields } from "convex/server";
 import {
   type DatabaseWriter,
   internalMutation,
@@ -16,6 +22,7 @@ import {
   replaceHandler,
   replaceOrInsertHandler,
 } from "./btree.js";
+import type { Doc } from "./_generated/dataModel.js";
 
 export function batchMaxBytes(metrics: TransactionMetrics): number {
   const { used, remaining } = metrics.bytesRead;
@@ -24,24 +31,57 @@ export function batchMaxBytes(metrics: TransactionMetrics): number {
 
 export const BATCH_MAX_OPERATIONS = 1024;
 export const MAX_OPERATIONS_PER_ENTRY = 512;
+export const MAX_BYTES_PER_ENTRY = 100 * 1024;
 
 export const OPS_WORKER_NAME = "ops";
 
-export async function enqueueOperation(ctx: MutationCtx, operation: Operation) {
+export async function enqueueOperations(
+  ctx: MutationCtx,
+  operations: Operation[],
+) {
+  if (operations.length === 0) {
+    return;
+  }
+  const sizes = operations.map((operation) => getConvexSize(operation));
   const newestEntry = await ctx.db
     .query("pendingOperations")
     .withIndex("by_commitTs", (q) => q.eq("commitTs", ctx.db.vars.commitTs))
     .order("desc")
     .first();
-  if (newestEntry && newestEntry.operations.length < MAX_OPERATIONS_PER_ENTRY) {
-    await ctx.db.patch("pendingOperations", newestEntry._id, {
-      operations: [...newestEntry.operations, operation],
-    });
-  } else {
-    await ctx.db.insert("pendingOperations", {
+  let index = 0;
+  if (newestEntry) {
+    const patch = { operations: [...newestEntry.operations] };
+    let bytes = getDocumentSize(newestEntry);
+    while (
+      index < operations.length &&
+      patch.operations.length < MAX_OPERATIONS_PER_ENTRY &&
+      bytes + sizes[index] <= MAX_BYTES_PER_ENTRY
+    ) {
+      bytes += sizes[index];
+      patch.operations.push(operations[index]);
+      index++;
+    }
+    if (patch.operations.length > newestEntry.operations.length) {
+      await ctx.db.patch("pendingOperations", newestEntry._id, patch);
+    }
+  }
+  while (index < operations.length) {
+    const entry: WithoutSystemFields<Doc<"pendingOperations">> = {
       commitTs: ctx.db.vars.commitTs,
-      operations: [operation],
-    });
+      operations: [],
+    };
+    let bytes = getDocumentSize(entry);
+    while (
+      index < operations.length &&
+      entry.operations.length < MAX_OPERATIONS_PER_ENTRY &&
+      (entry.operations.length === 0 ||
+        bytes + sizes[index] <= MAX_BYTES_PER_ENTRY)
+    ) {
+      bytes += sizes[index];
+      entry.operations.push(operations[index]);
+      index++;
+    }
+    await ctx.db.insert("pendingOperations", entry);
   }
   await ping(ctx, components.batchWorker, {
     // TODO: explore separate queues by namespace


### PR DESCRIPTION
Add an enqueueBatch mutation to the component that allows you to enqueue multiple operations in one call to the component.

This also changes enqueue to split a `pendingOperations` entry when it is about to exceed the document size limit. Previously the enqueue would fail.